### PR TITLE
Update ineligible_endpoint.yaml to incl HPA

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -351,4 +351,70 @@
   link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 - endpoint: replaceRbacAuthorizationV1NamespacedRoleBinding
   reason: optional feature
-  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/ 
+  link: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- endpoint: createAutoscalingV1NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: deleteAutoscalingV1NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: listAutoscalingV1NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: patchAutoscalingV1NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: readAutoscalingV1NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: replaceAutoscalingV1NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: createAutoscalingV2NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: deleteAutoscalingV2CollectionNamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: deleteAutoscalingV2NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: listAutoscalingV2HorizontalPodAutoscalerForAllNamespaces
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: listAutoscalingV2NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: patchAutoscalingV2NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: patchAutoscalingV2NamespacedHorizontalPodAutoscalerStatus
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: readAutoscalingV2NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: readAutoscalingV2NamespacedHorizontalPodAutoscalerStatus
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: replaceAutoscalingV2NamespacedHorizontalPodAutoscaler
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756
+- endpoint: replaceAutoscalingV2NamespacedHorizontalPodAutoscalerStatus
+  reason: optional feature
+  link: https://github.com/kubernetes/kubernetes/pull/106595#issuecomment-1006015756


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Add HPA to ineligible_endpoint.yaml as it is an optional feature

**Special notes for your reviewer:**
As of 1.22 APISnoop [Ineligible endpoints](https://apisnoop.cncf.io/conformance-progress/ineligible-endpoints) are pulled from the community owned `inelegible_endpoint.yaml` file

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance